### PR TITLE
Make diff-splatting example not resizable.

### DIFF
--- a/experiments/diff-splatting/app.py
+++ b/experiments/diff-splatting/app.py
@@ -11,7 +11,7 @@ class App:
 
         # Create a window
         self._window = spy.Window(
-            width=width, height=height, title=title, resizable=True
+            width=width, height=height, title=title, resizable=False
         )
 
         # Create a device with local include path for shaders


### PR DESCRIPTION
This example depends on an image display size that's evenly divisible by workgroup dimensions. It should not be resizeable.