### PR TITLE
samples: Fix crash with neuralnetwork expt.

### DIFF
--- a/experiments/neuralnetwork/main.py
+++ b/experiments/neuralnetwork/main.py
@@ -86,10 +86,13 @@ def training_main():
     uv_grid = create_uv_grid(device, resolution)
 
     timer = Timer()
-    command_encoder = device.create_command_encoder()
 
     while app.process_events():
         timer.start()
+
+        # The command encoder has to be created on each iteration since command_encoder.finish()
+        # closes it and the only way to open one is to create a new one.
+        command_encoder = device.create_command_encoder()
 
         # For a bit of extra performance, don't call module.trainTexture(....) directly,
         # but collect multiple calls into a command buffer and dispatch them as a big


### PR DESCRIPTION
Running the neuralnetwork sample causes the sample to crash with the backtrace present at
https://github.com/shader-slang/slangpy/issues/246#issuecomment-2919601775

This change fixes the crash by creating the command encoder on each iteration of training since the training pass closes the command encoder at the end, requiring the command encoder to be re-opened at the beginning of the next iteration and the only way to open a command encoder is to create a new one.

Fixes Slangpy Issue #246