### PR TITLE
Enable linux tests

### DIFF
--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -409,22 +409,16 @@ def test_toy_restir(example_runner: ExampleRunner, device_type: str):
 
 @pytest.mark.parametrize("device_type", DEVICE_TYPES)
 def test_type_methods(example_runner: ExampleRunner, device_type: str):
-    if sys.platform == "linux" or sys.platform == "linux2":
-        pytest.skip("Example currently crashes on Linux")
     example_runner.run("type_methods/main.py", device_type)
 
 
 @pytest.mark.parametrize("device_type", DEVICE_TYPES)
 def test_type_methods_main_instancelists(example_runner: ExampleRunner, device_type: str):
-    if sys.platform == "linux" or sys.platform == "linux2":
-        pytest.skip("Example currently crashes on Linux")
     example_runner.run("type_methods/main_instancelists.py", device_type)
 
 
 @pytest.mark.parametrize("device_type", DEVICE_TYPES)
 def test_type_methods_extend_instancelists(example_runner: ExampleRunner, device_type: str):
-    if sys.platform == "linux" or sys.platform == "linux2":
-        pytest.skip("Example currently crashes on Linux")
     example_runner.run("type_methods/extend_instancelists.py", device_type)
 
 


### PR DESCRIPTION
These tests previously crashed on Vulkan due to not releasing the device correctly.
This is fixed with https://github.com/shader-slang/slangpy/pull/426