### PR TITLE
Add demo for neural.slang

### DIFF
--- a/examples/neural_slang_demo/README.md
+++ b/examples/neural_slang_demo/README.md
@@ -9,6 +9,7 @@ This is a re-creation of the texture example in the https://github.com/shader-sl
 
 | Type | Description |
 |------|-------------|
+| `IVector<T>` | Interface for all vector types, enabling link-time type selection |
 | `InlineVector<T, N>` | Fixed-size vector type with compile-time `.Size` constant |
 | `WaveTangledVector<T, Pool, N, WaveSize>` | Cooperative-matrix-accelerated vector (requires GPU support) |
 | `StructuredBufferStorage<T>` | GPU buffer storage implementing `IStorage<T>` interface |
@@ -16,6 +17,7 @@ This is a re-creation of the texture example in the https://github.com/shader-sl
 | `LinearLayout` | Storage layout for standard linear (row-major) weight packing |
 | `LeakyReLU<T>` | Leaky ReLU activation with configurable alpha (default 0.01) |
 | `ExpActivation<T>` | Exponential activation: `exp(x)` |
+| `SharedMemorySize` / `SharedMemoryPool` | Shared memory allocation for `WaveTangledVector` cooperative operations |
 
 ## Before/After Comparison
 
@@ -34,10 +36,10 @@ Approximate lines of code comparison apart from comments.
 
 | Before (Manual) | After (neural.slang) |
 |-----------------|---------------------|
-| `float[4]` / `float4` | `InlineVector<float, 4>` |
-| `float[32]` | `InlineVector<float, 32>` |
-| `float[3]` / `float3` | `InlineVector<float, 3>` |
-| Manual size tracking | `InlineVector.Size` compile-time constant |
+| `float[4]` / `float4` | `InputVec` (link-time: `InlineVector<float, 4>` or `WaveTangledVector`) |
+| `float[32]` | `HiddenVec` (link-time: `InlineVector<float, 32>` or `WaveTangledVector`) |
+| `float[3]` / `float3` | `OutputVec` (link-time: `InlineVector<float, 3>` or `WaveTangledVector`) |
+| Manual size tracking | `IVector.Size` compile-time constant |
 
 ### Parameter Storage
 
@@ -98,11 +100,16 @@ float3 eval(no_diff float2 uv)
 
 **After:**
 ```slang
+// All vector types are extern structs resolved at link time
+extern struct InputVec : IVector<float>;
+extern struct HiddenVec : IVector<float>;
+extern struct OutputVec : IVector<float>;
+
 // Type aliases using FFLayer with Layout and Activation parameters
 typealias Storage = StructuredBufferStorage<float>;
-typealias Layer0 = FFLayer<float, InputVec, HiddenVec, Storage, LinearLayout, LeakyReLU<float>>;
-typealias Layer1 = FFLayer<float, HiddenVec, HiddenVec, Storage, LinearLayout, LeakyReLU<float>>;
-typealias Layer2 = FFLayer<float, HiddenVec, OutputVec, Storage, LinearLayout, ExpActivation<float>>;
+typealias Layer0 = FFLayer<float, InputVec, HiddenVec, Storage, LinearLayout, LeakyReLU<float>, true>;
+typealias Layer1 = FFLayer<float, HiddenVec, HiddenVec, Storage, LinearLayout, LeakyReLU<float>, true>;
+typealias Layer2 = FFLayer<float, HiddenVec, OutputVec, Storage, LinearLayout, ExpActivation<float>, true>;
 
 // Network evaluation with FFLayer and built-in activations
 [Differentiable]
@@ -127,12 +134,39 @@ OutputVec mlp_forward(Storage storage, InputVec input)
 
 ## Link-Time Type Selection
 
-The hidden vector type (`HiddenVec`) is declared as an `extern struct` in `neural-demo.slang`, making it a link-time type. Separate `.slang` files provide the concrete implementation, and the Python script links the appropriate one based on a command-line flag:
+All three vector types (`InputVec`, `HiddenVec`, `OutputVec`) are declared as `extern struct` in `neural-demo.slang`, making them link-time types. Separate `.slang` files provide the concrete implementations, and the Python script links the appropriate one based on a command-line flag:
 
-- **`neural-demo-inline.slang`:** `HiddenVec = InlineVector<float, 32>` — standard fixed-size vector (default)
-- **`neural-demo-wave.slang`:** `HiddenVec = WaveTangledVector<float, ShMemPool, 32, 32>` — cooperative-matrix-accelerated vector
+**`neural-demo-inline.slang`** (default):
+```slang
+export struct InputVec : IVector<float> = InlineVector<float, 4>;
+export struct HiddenVec : IVector<float> = InlineVector<float, 32>;
+export struct OutputVec : IVector<float> = InlineVector<float, 3>;
+```
 
-Only `HiddenVec` (32-dim) is a link-time type because `FFLayer.eval()` is generic over vector types, so an `InlineVector` input naturally produces a `WaveTangledVector` hidden output. Input (4-dim) and output (3-dim) vectors are too small to benefit from cooperative matrix acceleration.
+**`neural-demo-wave.slang`** (accelerated):
+```slang
+typealias ShMemSizeForNetwork = ShMemSize.OfLayer3<4, 32, 32, 3>;
+typealias ShMemPool = SharedMemoryPool<ShMemSizeForNetwork>;
+
+export struct InputVec : IVector<float> = WaveTangledVector<float, ShMemPool, 4, SubgroupSize>;
+export struct HiddenVec : IVector<float> = WaveTangledVector<float, ShMemPool, 32, SubgroupSize>;
+export struct OutputVec : IVector<float> = WaveTangledVector<float, ShMemPool, 3, SubgroupSize>;
+```
+
+Because `FFLayer.eval()` is generic over `IVector<T>` types, the main network code (`neural-demo.slang`) is completely agnostic to the underlying vector implementation. Swapping between `InlineVector` and `WaveTangledVector` requires no changes to the network logic.
+
+The wave variant uses `SharedMemorySize.OfLayer3<4, 32, 32, 3>` to compute the shared memory pool size across all three layers of the network (4->32, 32->32, 32->3).
+
+## File Structure
+
+| File | Description |
+|------|-------------|
+| `neural-demo.slang` | Main network: extern vector declarations, MLP forward pass, loss, training |
+| `neural-demo-inline.slang` | Link module: all vectors as `InlineVector` |
+| `neural-demo-wave.slang` | Link module: all vectors as `WaveTangledVector` with shared memory pool |
+| `neural-demo.py` | Python driver: device setup, link module selection, training loop |
+| `app.py` | Windowing and display utilities |
+| `app.slang` | Blit/tonemap helper shaders |
 
 ## Running the Demo
 

--- a/examples/neural_slang_demo/README.md
+++ b/examples/neural_slang_demo/README.md
@@ -9,9 +9,10 @@ This is a re-creation of the texture example in the https://github.com/shader-sl
 |------|-------------|
 | `InlineVector<T, N>` | Fixed-size vector type with compile-time `.Size` constant |
 | `StructuredBufferStorage<T>` | GPU buffer storage implementing `IStorage<T>` interface |
-| `FFLayer<T, InVec, OutVec, Storage, Activation, HasBias>` | Feed-forward neural network layer |
-| `IdentityActivation<T>` | Pass-through activation (no transformation) |
-| `NoParam()` | Empty parameter for activations that don't need configuration |
+| `FFLayer<T, InVec, OutVec, Storage, Layout, Activation, HasBias>` | Feed-forward neural network layer |
+| `LinearLayout` | Storage layout for standard linear (row-major) weight packing |
+| `LeakyReLU<T>` | Leaky ReLU activation with configurable alpha (default 0.01) |
+| `ExpActivation<T>` | Exponential activation: `exp(x)` |
 
 ## Before/After Comparison
 
@@ -33,7 +34,7 @@ Approximate lines of code comparison apart from comments.
 | `float[4]` / `float4` | `InlineVector<float, 4>` |
 | `float[32]` | `InlineVector<float, 32>` |
 | `float[3]` / `float3` | `InlineVector<float, 3>` |
-| Manual size tracking | `Vec4.Size` compile-time constant |
+| Manual size tracking | `InlineVector.Size` compile-time constant |
 
 ### Parameter Storage
 
@@ -94,6 +95,12 @@ float3 eval(no_diff float2 uv)
 
 **After:**
 ```slang
+// Type aliases using FFLayer with Layout and Activation parameters
+typealias Storage = StructuredBufferStorage<float>;
+typealias Layer0 = FFLayer<float, InputVec, HiddenVec, Storage, LinearLayout, LeakyReLU<float>>;
+typealias Layer1 = FFLayer<float, HiddenVec, HiddenVec, Storage, LinearLayout, LeakyReLU<float>>;
+typealias Layer2 = FFLayer<float, HiddenVec, OutputVec, Storage, LinearLayout, ExpActivation<float>>;
+
 // Network evaluation with FFLayer and built-in activations
 [Differentiable]
 OutputVec mlp_forward(Storage storage, InputVec input)
@@ -118,7 +125,7 @@ OutputVec mlp_forward(Storage storage, InputVec input)
 ## Running the Demo
 
 ```bash
-cd slangpy-samples/examples/neural-demo
+cd slangpy-samples/examples/neural_slang_demo
 python neural-demo.py
 ```
 

--- a/examples/neural_slang_demo/README.md
+++ b/examples/neural_slang_demo/README.md
@@ -10,6 +10,7 @@ This is a re-creation of the texture example in the https://github.com/shader-sl
 | Type | Description |
 |------|-------------|
 | `InlineVector<T, N>` | Fixed-size vector type with compile-time `.Size` constant |
+| `WaveTangledVector<T, Pool, N, WaveSize>` | Cooperative-matrix-accelerated vector (requires GPU support) |
 | `StructuredBufferStorage<T>` | GPU buffer storage implementing `IStorage<T>` interface |
 | `FFLayer<T, InVec, OutVec, Storage, Layout, Activation, HasBias>` | Feed-forward neural network layer |
 | `LinearLayout` | Storage layout for standard linear (row-major) weight packing |
@@ -124,11 +125,25 @@ OutputVec mlp_forward(Storage storage, InputVec input)
 | Hardcoded dimensions | Dimensions from vector types |
 | Manual weight indexing | Automatic address calculation |
 
+## Link-Time Type Selection
+
+The hidden vector type (`HiddenVec`) is declared as an `extern struct` in `neural-demo.slang`, making it a link-time type. Separate `.slang` files provide the concrete implementation, and the Python script links the appropriate one based on a command-line flag:
+
+- **`neural-demo-inline.slang`:** `HiddenVec = InlineVector<float, 32>` — standard fixed-size vector (default)
+- **`neural-demo-wave.slang`:** `HiddenVec = WaveTangledVector<float, ShMemPool, 32, 32>` — cooperative-matrix-accelerated vector
+
+Only `HiddenVec` (32-dim) is a link-time type because `FFLayer.eval()` is generic over vector types, so an `InlineVector` input naturally produces a `WaveTangledVector` hidden output. Input (4-dim) and output (3-dim) vectors are too small to benefit from cooperative matrix acceleration.
+
 ## Running the Demo
 
 ```bash
 cd slangpy-samples/examples/neural_slang_demo
+
+# Default mode (InlineVector)
 python neural-demo.py
+
+# Accelerated mode (WaveTangledVector, requires cooperative matrix GPU support)
+python neural-demo.py --vector-type wave
 ```
 
 The demo displays three panels:

--- a/examples/neural_slang_demo/README.md
+++ b/examples/neural_slang_demo/README.md
@@ -1,5 +1,7 @@
 # Neural Demo - Using neural.slang
 
+![Screenshot](screenshot.png)
+
 This demo showcases how to use Slang's `neural.slang` standard module to build a neural network for image reconstruction. The network learns to map UV coordinates to RGB colors, reconstructing a reference image through gradient-based optimization.
 This is a re-creation of the texture example in the https://github.com/shader-slang/neural-shading-s25 course.
 

--- a/examples/neural_slang_demo/README.md
+++ b/examples/neural_slang_demo/README.md
@@ -1,0 +1,130 @@
+# Neural Demo - Using neural.slang
+
+This demo showcases how to use Slang's `neural.slang` standard module to build a neural network for image reconstruction. The network learns to map UV coordinates to RGB colors, reconstructing a reference image through gradient-based optimization.
+This is a re-creation of the texture example in the https://github.com/shader-slang/neural-shading-s25 course.
+
+## neural.slang Types Used
+
+| Type | Description |
+|------|-------------|
+| `InlineVector<T, N>` | Fixed-size vector type with compile-time `.Size` constant |
+| `StructuredBufferStorage<T>` | GPU buffer storage implementing `IStorage<T>` interface |
+| `FFLayer<T, InVec, OutVec, Storage, Activation, HasBias>` | Feed-forward neural network layer |
+| `IdentityActivation<T>` | Pass-through activation (no transformation) |
+| `NoParam()` | Empty parameter for activations that don't need configuration |
+
+## Before/After Comparison
+
+This section shows the comparison between the original code and the code with the neural.slang APIs
+
+### Lines of Code
+
+Approximate lines of code comparison apart from comments.
+
+| File Type | Original | neural.slang |
+|-----------|----------|--------------|
+| Slang | 171 | 105 |
+| Python | 103 | 68 |
+
+### Vector Types
+
+| Before (Manual) | After (neural.slang) |
+|-----------------|---------------------|
+| `float[4]` / `float4` | `InlineVector<float, 4>` |
+| `float[32]` | `InlineVector<float, 32>` |
+| `float[3]` / `float3` | `InlineVector<float, 3>` |
+| Manual size tracking | `Vec4.Size` compile-time constant |
+
+### Parameter Storage
+
+| Before (Manual) | After (neural.slang) |
+|-----------------|---------------------|
+| Separate weight/bias buffers | `StructuredBufferStorage<T>` wrapper |
+| Manual offset calculation | `Storage.getOffset()` method |
+| Manual parameter count | `FFLayer.ParameterCount` constant |
+
+### Layer Forward Pass
+
+| Before (Manual) | After (neural.slang) |
+|-----------------|---------------------|
+| Manual matrix multiply | `FFLayer.eval()` using `linearTransform` |
+| Explicit loops | Optimized internal implementation |
+| Manual bias addition | Handled by `FFLayer` |
+
+**Before:**
+```slang
+// Single layer forward pass
+[Differentiable]
+float[Outputs] forward(float[Inputs] x)
+{
+    float[Outputs] y;
+    [MaxIters(Outputs)]
+    for (int row = 0; row < Outputs; ++row)
+    {
+        var sum = get_bias(row);
+        [ForceUnroll]
+        for (int col = 0; col < Inputs; ++col)
+            sum += get_weight(row, col) * x[col];
+        y[row] = sum;
+    }
+    return y;
+}
+
+// Network evaluation with manual activation loops
+[Differentiable]
+float3 eval(no_diff float2 uv)
+{
+    float encoded_inputs[NumLatents] = latent_texture.sample(uv);
+
+    float output0[32] = layer0.forward(encoded_inputs);
+    [ForceUnroll]
+    for (int i = 0; i < 32; ++i)
+        output0[i] = leakyReLU(output0[i]);
+    float output1[32] = layer1.forward(output0);
+    [ForceUnroll]
+    for (int i = 0; i < 32; ++i)
+        output1[i] = leakyReLU(output1[i]);
+    float output2[3] = layer2.forward(output1);
+    [ForceUnroll]
+    for (int i = 0; i < 3; ++i)
+        output2[i] = exp(output2[i]);
+    return float3(output2[0], output2[1], output2[2]);
+}
+```
+
+**After:**
+```slang
+// Network evaluation with FFLayer and built-in activations
+[Differentiable]
+OutputVec mlp_forward(Storage storage, InputVec input)
+{
+    uint addr = 0u;
+    let h0 = Layer0(addr, addr + INPUT_DIM * HIDDEN_DIM, LeakyReLU<float>(LEAKY_RELU_SLOPE)).eval<Storage>(storage, input);
+    addr = Layer0.nextAddress(addr);
+    let h1 = Layer1(addr, addr + HIDDEN_DIM * HIDDEN_DIM, LeakyReLU<float>(LEAKY_RELU_SLOPE)).eval<Storage>(storage, h0);
+    addr = Layer1.nextAddress(addr);
+    return Layer2(addr, addr + HIDDEN_DIM * OUTPUT_DIM, ExpActivation<float>()).eval<Storage>(storage, h1);
+}
+```
+
+### Network Definition
+
+| Before (Manual) | After (neural.slang) |
+|-----------------|---------------------|
+| Custom struct with manual layout | Type aliases for layers |
+| Hardcoded dimensions | Dimensions from vector types |
+| Manual weight indexing | Automatic address calculation |
+
+## Running the Demo
+
+```bash
+cd slangpy-samples/examples/neural-demo
+python neural-demo.py
+```
+
+The demo displays three panels:
+1. **Reference image** - Target to reconstruct
+2. **Network output** - Current reconstruction using FFLayer-based network
+3. **Loss visualization** - Per-pixel error
+
+Loss values are printed to console and should decrease over time as the network learns.

--- a/examples/neural_slang_demo/app.py
+++ b/examples/neural_slang_demo/app.py
@@ -1,0 +1,156 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Callable, Optional
+import slangpy as spy
+from pathlib import Path
+
+
+class App:
+    def __init__(
+        self,
+        title: str = "Forward Rasterizer Example",
+        width: int = 1024,
+        height: int = 1024,
+        device_type: spy.DeviceType = spy.DeviceType.automatic,
+    ):
+        super().__init__()
+
+        # Create spy window
+        self._window = spy.Window(width=width, height=height, title=title, resizable=False)
+
+        # Create spy device with local include path for shaders
+        self._device = spy.create_device(
+            device_type, enable_debug_layers=True, include_paths=[Path(__file__).parent]
+        )
+
+        # Load module of helpers
+        self._module = spy.Module.load_from_file(self._device, "app.slang")
+
+        # Setup swapchain
+        self.surface = self._device.create_surface(self._window)
+        self.surface.configure(width=self._window.width, height=self._window.height)
+
+        # Will contain output texture
+        self._output_texture: "spy.Texture" = self.device.create_texture(
+            format=spy.Format.rgba16_float,
+            width=width,
+            height=height,
+            mip_count=1,
+            usage=spy.TextureUsage.shader_resource | spy.TextureUsage.unordered_access,
+            label="output_texture",
+        )
+
+        # Store mouse pos
+        self._mouse_pos = spy.float2()
+
+        # Internal events
+        self._window.on_keyboard_event = self._on_window_keyboard_event
+        self._window.on_mouse_event = self._on_window_mouse_event
+        self._window.on_resize = self._on_window_resize
+
+        # Hookable events
+        self.on_keyboard_event: Optional[Callable[[spy.KeyboardEvent], None]] = None
+        self.on_mouse_event: Optional[Callable[[spy.MouseEvent], None]] = None
+
+    @property
+    def device(self) -> spy.Device:
+        return self._device
+
+    @property
+    def window(self) -> spy.Window:
+        return self._window
+
+    @property
+    def mouse_pos(self) -> spy.float2:
+        return self._mouse_pos
+
+    @property
+    def output(self) -> spy.Texture:
+        return self._output_texture
+
+    def process_events(self):
+        if self._window.should_close():
+            return False
+        self._window.process_events()
+        return True
+
+    def present(self):
+        if not self.surface.config:
+            return
+        image = self.surface.acquire_next_image()
+        if not image:
+            return
+
+        if (
+            self._output_texture == None
+            or self._output_texture.width != image.width
+            or self._output_texture.height != image.height
+        ):
+            self._output_texture = self.device.create_texture(
+                format=spy.Format.rgba16_float,
+                width=image.width,
+                height=image.height,
+                mip_count=1,
+                usage=spy.TextureUsage.shader_resource | spy.TextureUsage.unordered_access,
+                label="output_texture",
+            )
+
+        command_encoder = self._device.create_command_encoder()
+        command_encoder.blit(image, self._output_texture)
+        command_encoder.set_texture_state(image, spy.ResourceState.present)
+        self._device.submit_command_buffer(command_encoder.finish())
+
+        del image
+        self.surface.present()
+
+    def blit(
+        self,
+        source: spy.Tensor,
+        size: Optional[spy.int2] = None,
+        offset: Optional[spy.int2] = None,
+        tonemap: bool = True,
+        bilinear: bool = False,
+    ):
+        if len(source.shape) != 2:
+            raise ValueError("Source tensor must be 2D (height, width).")
+        if size is None:
+            size = spy.int2(source.shape[1], source.shape[0])
+        if offset is None:
+            offset = spy.int2(0, 0)
+        self._module.blit(
+            spy.grid((size.y, size.x)), size, offset, tonemap, bilinear, source, self.output
+        )
+
+    def _on_window_keyboard_event(self, event: spy.KeyboardEvent):
+        if event.type == spy.KeyboardEventType.key_press:
+            if event.key == spy.KeyCode.escape:
+                self._window.close()
+                return
+            elif event.key == spy.KeyCode.f1:
+                if self._output_texture:
+                    spy.tev.show_async(self._output_texture)
+                return
+            elif event.key == spy.KeyCode.f2:
+                if self._output_texture:
+                    bitmap = self._output_texture.to_bitmap()
+                    bitmap.convert(
+                        spy.Bitmap.PixelFormat.rgb,
+                        spy.Bitmap.ComponentType.uint8,
+                        srgb_gamma=True,
+                    ).write_async("screenshot.png")
+                return
+        if self.on_keyboard_event:
+            self.on_keyboard_event(event)
+
+    def _on_window_mouse_event(self, event: spy.MouseEvent):
+        if event.type == spy.MouseEventType.move:
+            self._mouse_pos = event.pos
+        if self.on_mouse_event:
+            self.on_mouse_event(event)
+
+    def _on_window_resize(self, width: int, height: int):
+        self._device.wait()
+        if width > 0 and height > 0:
+            self.surface.configure(width=width, height=height)
+        else:
+            self.surface.unconfigure()

--- a/examples/neural_slang_demo/app.slang
+++ b/examples/neural_slang_demo/app.slang
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import slangpy;
+
+// Helper function to turn pixel coordinates into normalized UVs.
+float2 pixel_to_uv(int2 pixel, int2 resolution)
+{
+    return (float2(pixel) + 0.5f) / float2(resolution);
+}
+
+float3 tonemap_aces_film(float3 input)
+{
+    float3 x = input.xyz;
+    float a = 2.51;
+    float b = 0.03;
+    float c = 2.43;
+    float d = 0.59;
+    float e = 0.14;
+    float3 col = saturate((x * (a * x + b)) / (x * (c * x + d) + e));
+    return col;
+}
+
+void blit(
+    int2 pixel,
+    int2 size,
+    int2 offset,
+    bool tonemap,
+    bool bilinear,
+    Tensor<float3, 2> input,
+    RWTexture2D<float4> output,
+)
+{
+    uint2 output_dimensions;
+    output.GetDimensions(output_dimensions.x, output_dimensions.y);
+
+    float2 uv = pixel_to_uv(pixel, size);
+
+    uint[2] shape = input.shape;
+
+    float3 col = bilinear ?
+        input.sample(uv) :
+        input.getv(uint2(float2(shape[1], shape[0]) * uv));
+
+    col = abs(col);
+
+    if(tonemap)
+    {
+        col = tonemap_aces_film(col);
+    }
+
+    if(any(isnan(col.x)))
+    {
+        output[offset + pixel] = float4(1,0,1,1);
+    }
+    else
+    {
+        output[offset + pixel] = float4(col, 1.0f);
+
+    }
+
+}

--- a/examples/neural_slang_demo/neural-demo-inline.slang
+++ b/examples/neural_slang_demo/neural-demo-inline.slang
@@ -5,4 +5,33 @@ export struct InputVec : IVector<float> = InlineVector<float, 4>;
 export struct HiddenVec : IVector<float> = InlineVector<float, 32>;
 export struct OutputVec : IVector<float> = InlineVector<float, 3>;
 
-export float3 outputToFloat3(InlineVector<float, 3> v) { return float3(v[0], v[1], v[2]); }
+typealias ConcreteInput = InlineVector<float, 4>;
+typealias ConcreteOutput = InlineVector<float, 3>;
+
+// WAR: InlineVector.__init is not yet differentiable, operator[] is internal
+InputVec _makeInputVec(float data[4]) { return bit_cast<InputVec>(ConcreteInput(data)); }
+float3 _extractFloat3(OutputVec v) { ConcreteOutput cv = bit_cast<ConcreteOutput>(v); return float3(cv[0], cv[1], cv[2]); }
+
+[Differentiable] export InputVec arrayToInputVec(float data[4]) { return no_diff _makeInputVec(data); }
+
+[BackwardDerivativeOf(arrayToInputVec)]
+void arrayToInputVec_bwd(inout DifferentialPair<float[4]> dpData, InputVec.Differential dResult)
+{
+    ConcreteInput.Differential dr = bit_cast<ConcreteInput.Differential>(dResult);
+    float dd[4];
+    [ForceUnroll] for (int i = 0; i < 4; ++i) dd[i] = dpData.d[i] + dr[i];
+    dpData = diffPair(dpData.p, dd);
+}
+
+[Differentiable] export float3 outputToFloat3(OutputVec v) { return no_diff _extractFloat3(v); }
+
+[BackwardDerivativeOf(outputToFloat3)]
+void outputToFloat3_bwd(inout DifferentialPair<OutputVec> dpV, float3 dResult)
+{
+    var concreteDp = bit_cast<DifferentialPair<ConcreteOutput>>(dpV);
+    ConcreteOutput.Differential dv = concreteDp.d;
+    dv[0] = dv[0] + dResult.x;
+    dv[1] = dv[1] + dResult.y;
+    dv[2] = dv[2] + dResult.z;
+    dpV = bit_cast<DifferentialPair<OutputVec>>(diffPair(concreteDp.p, dv));
+}

--- a/examples/neural_slang_demo/neural-demo-inline.slang
+++ b/examples/neural_slang_demo/neural-demo-inline.slang
@@ -8,7 +8,7 @@ export struct OutputVec : IVector<float> = InlineVector<float, 3>;
 typealias ConcreteInput = InlineVector<float, 4>;
 typealias ConcreteOutput = InlineVector<float, 3>;
 
-// WAR: InlineVector.__init is not yet differentiable, operator[] is internal
+// WAR: InlineVector.__init/operator[] not yet differentiable — manual backward via bit_cast.
 InputVec _makeInputVec(float data[4]) { return bit_cast<InputVec>(ConcreteInput(data)); }
 float3 _extractFloat3(OutputVec v) { ConcreteOutput cv = bit_cast<ConcreteOutput>(v); return float3(cv[0], cv[1], cv[2]); }
 

--- a/examples/neural_slang_demo/neural-demo-inline.slang
+++ b/examples/neural_slang_demo/neural-demo-inline.slang
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
+import neural;
+
+export struct HiddenVec : IVector<float> = InlineVector<float, 32>;

--- a/examples/neural_slang_demo/neural-demo-inline.slang
+++ b/examples/neural_slang_demo/neural-demo-inline.slang
@@ -1,4 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import neural;
 
+export struct InputVec : IVector<float> = InlineVector<float, 4>;
 export struct HiddenVec : IVector<float> = InlineVector<float, 32>;
+export struct OutputVec : IVector<float> = InlineVector<float, 3>;

--- a/examples/neural_slang_demo/neural-demo-inline.slang
+++ b/examples/neural_slang_demo/neural-demo-inline.slang
@@ -4,3 +4,5 @@ import neural;
 export struct InputVec : IVector<float> = InlineVector<float, 4>;
 export struct HiddenVec : IVector<float> = InlineVector<float, 32>;
 export struct OutputVec : IVector<float> = InlineVector<float, 3>;
+
+export float3 outputToFloat3(InlineVector<float, 3> v) { return float3(v[0], v[1], v[2]); }

--- a/examples/neural_slang_demo/neural-demo-wave.slang
+++ b/examples/neural_slang_demo/neural-demo-wave.slang
@@ -4,9 +4,11 @@ import neural;
 static const int SubgroupSize = 32;
 static const int SubgroupCount = 1;
 
-// SharedMemoryPool for the 2 WaveTangledVector layers: 32->32 and 32->3
+// SharedMemoryPool for the 3 WaveTangledVector layers: 4->32, 32->32, 32->3
 typealias ShMemSize = SharedMemorySize<float, TargetEnum.SPIR_V, ExecutionMode.Training, SubgroupSize, SubgroupCount>;
-typealias ShMemSizeForNetwork = ShMemSize.OfLayer2<32, 32, 3>;
+typealias ShMemSizeForNetwork = ShMemSize.OfLayer3<4, 32, 32, 3>;
 typealias ShMemPool = SharedMemoryPool<ShMemSizeForNetwork>;
 
+export struct InputVec : IVector<float> = WaveTangledVector<float, ShMemPool, 4, SubgroupSize>;
 export struct HiddenVec : IVector<float> = WaveTangledVector<float, ShMemPool, 32, SubgroupSize>;
+export struct OutputVec : IVector<float> = WaveTangledVector<float, ShMemPool, 3, SubgroupSize>;

--- a/examples/neural_slang_demo/neural-demo-wave.slang
+++ b/examples/neural_slang_demo/neural-demo-wave.slang
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+import neural;
+
+static const int SubgroupSize = 32;
+static const int SubgroupCount = 1;
+
+// SharedMemoryPool for the 2 WaveTangledVector layers: 32->32 and 32->3
+typealias ShMemSize = SharedMemorySize<float, TargetEnum.SPIR_V, ExecutionMode.Training, SubgroupSize, SubgroupCount>;
+typealias ShMemSizeForNetwork = ShMemSize.OfLayer2<32, 32, 3>;
+typealias ShMemPool = SharedMemoryPool<ShMemSizeForNetwork>;
+
+export struct HiddenVec : IVector<float> = WaveTangledVector<float, ShMemPool, 32, SubgroupSize>;

--- a/examples/neural_slang_demo/neural-demo-wave.slang
+++ b/examples/neural_slang_demo/neural-demo-wave.slang
@@ -4,11 +4,12 @@ import neural;
 static const int SubgroupSize = 32;
 static const int SubgroupCount = 1;
 
-// SharedMemoryPool for the 3 WaveTangledVector layers: 4->32, 32->32, 32->3
+// SharedMemorySize for the 3 WaveTangledVector layers: 4->32, 32->32, 32->3
 typealias ShMemSize = SharedMemorySize<float, TargetEnum.SPIR_V, ExecutionMode.Training, SubgroupSize, SubgroupCount>;
 typealias ShMemSizeForNetwork = ShMemSize.OfLayer3<4, 32, 32, 3>;
-typealias ShMemPool = SharedMemoryPool<ShMemSizeForNetwork>;
 
-export struct InputVec : IVector<float> = WaveTangledVector<float, ShMemPool, 4, SubgroupSize>;
-export struct HiddenVec : IVector<float> = WaveTangledVector<float, ShMemPool, 32, SubgroupSize>;
-export struct OutputVec : IVector<float> = WaveTangledVector<float, ShMemPool, 3, SubgroupSize>;
+export struct InputVec : IVector<float> = WaveTangledVector<float, ShMemSizeForNetwork, 4, SubgroupSize>;
+export struct HiddenVec : IVector<float> = WaveTangledVector<float, ShMemSizeForNetwork, 32, SubgroupSize>;
+export struct OutputVec : IVector<float> = WaveTangledVector<float, ShMemSizeForNetwork, 3, SubgroupSize>;
+
+export float3 outputToFloat3(WaveTangledVector<float, ShMemSizeForNetwork, 3, SubgroupSize> v) { return float3(v[0], v[1], v[2]); }

--- a/examples/neural_slang_demo/neural-demo-wave.slang
+++ b/examples/neural_slang_demo/neural-demo-wave.slang
@@ -12,4 +12,43 @@ export struct InputVec : IVector<float> = WaveTangledVector<float, ShMemSizeForN
 export struct HiddenVec : IVector<float> = WaveTangledVector<float, ShMemSizeForNetwork, 32, SubgroupSize>;
 export struct OutputVec : IVector<float> = WaveTangledVector<float, ShMemSizeForNetwork, 3, SubgroupSize>;
 
-export float3 outputToFloat3(WaveTangledVector<float, ShMemSizeForNetwork, 3, SubgroupSize> v) { return float3(v[0], v[1], v[2]); }
+typealias ConcreteInput = WaveTangledVector<float, ShMemSizeForNetwork, 4, SubgroupSize>;
+typealias ConcreteOutput = WaveTangledVector<float, ShMemSizeForNetwork, 3, SubgroupSize>;
+
+// WAR: WaveTangledVector.__init and operator[] are not yet differentiable,
+// so we provide manual backward derivatives using bit_cast to concrete types.
+
+// Non-differentiable helpers that use WaveTangledVector operations directly
+InputVec _makeInputVec(float data[4]) { return bit_cast<InputVec>(ConcreteInput(data)); }
+float3 _extractFloat3(OutputVec v) { ConcreteOutput cv = bit_cast<ConcreteOutput>(v); return float3(cv[0], cv[1], cv[2]); }
+
+[Differentiable] export InputVec arrayToInputVec(float data[4])
+{
+    return no_diff _makeInputVec(data);
+}
+
+[BackwardDerivativeOf(arrayToInputVec)]
+void arrayToInputVec_bwd(inout DifferentialPair<float[4]> dpData, InputVec.Differential dResult)
+{
+    ConcreteInput.Differential dr = bit_cast<ConcreteInput.Differential>(dResult);
+    float dd[4];
+    [ForceUnroll] for (int i = 0; i < 4; ++i) dd[i] = dpData.d[i] + dr[i];
+    dpData = diffPair(dpData.p, dd);
+}
+
+[Differentiable] export float3 outputToFloat3(OutputVec v)
+{
+    return no_diff _extractFloat3(v);
+}
+
+[BackwardDerivativeOf(outputToFloat3)]
+void outputToFloat3_bwd(inout DifferentialPair<OutputVec> dpV, float3 dResult)
+{
+    // Work entirely in ConcreteOutput space to avoid type identity issues
+    var concreteDp = bit_cast<DifferentialPair<ConcreteOutput>>(dpV);
+    ConcreteOutput.Differential dv = concreteDp.d;
+    dv[0] = dv[0] + dResult.x;
+    dv[1] = dv[1] + dResult.y;
+    dv[2] = dv[2] + dResult.z;
+    dpV = bit_cast<DifferentialPair<OutputVec>>(diffPair(concreteDp.p, dv));
+}

--- a/examples/neural_slang_demo/neural-demo-wave.slang
+++ b/examples/neural_slang_demo/neural-demo-wave.slang
@@ -15,17 +15,11 @@ export struct OutputVec : IVector<float> = WaveTangledVector<float, ShMemSizeFor
 typealias ConcreteInput = WaveTangledVector<float, ShMemSizeForNetwork, 4, SubgroupSize>;
 typealias ConcreteOutput = WaveTangledVector<float, ShMemSizeForNetwork, 3, SubgroupSize>;
 
-// WAR: WaveTangledVector.__init and operator[] are not yet differentiable,
-// so we provide manual backward derivatives using bit_cast to concrete types.
-
-// Non-differentiable helpers that use WaveTangledVector operations directly
+// WAR: WaveTangledVector.__init/operator[] not yet differentiable — manual backward via bit_cast.
 InputVec _makeInputVec(float data[4]) { return bit_cast<InputVec>(ConcreteInput(data)); }
 float3 _extractFloat3(OutputVec v) { ConcreteOutput cv = bit_cast<ConcreteOutput>(v); return float3(cv[0], cv[1], cv[2]); }
 
-[Differentiable] export InputVec arrayToInputVec(float data[4])
-{
-    return no_diff _makeInputVec(data);
-}
+[Differentiable] export InputVec arrayToInputVec(float data[4]) { return no_diff _makeInputVec(data); }
 
 [BackwardDerivativeOf(arrayToInputVec)]
 void arrayToInputVec_bwd(inout DifferentialPair<float[4]> dpData, InputVec.Differential dResult)
@@ -36,15 +30,11 @@ void arrayToInputVec_bwd(inout DifferentialPair<float[4]> dpData, InputVec.Diffe
     dpData = diffPair(dpData.p, dd);
 }
 
-[Differentiable] export float3 outputToFloat3(OutputVec v)
-{
-    return no_diff _extractFloat3(v);
-}
+[Differentiable] export float3 outputToFloat3(OutputVec v) { return no_diff _extractFloat3(v); }
 
 [BackwardDerivativeOf(outputToFloat3)]
 void outputToFloat3_bwd(inout DifferentialPair<OutputVec> dpV, float3 dResult)
 {
-    // Work entirely in ConcreteOutput space to avoid type identity issues
     var concreteDp = bit_cast<DifferentialPair<ConcreteOutput>>(dpV);
     ConcreteOutput.Differential dv = concreteDp.d;
     dv[0] = dv[0] + dResult.x;

--- a/examples/neural_slang_demo/neural-demo.py
+++ b/examples/neural_slang_demo/neural-demo.py
@@ -3,14 +3,25 @@ from app import App
 import slangpy as spy
 import numpy as np
 from pathlib import Path
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--vector-type", choices=["inline", "wave"], default="inline")
+args = parser.parse_args()
+
+# WaveTangledVector requires cooperative matrix support (Vulkan/SPIR-V)
+device_type = spy.DeviceType.vulkan if args.vector_type == "wave" else spy.DeviceType.vulkan
 
 app = App(
     width=512 * 3 + 10 * 2,
     height=512,
     title="neural.slang demo",
-    device_type=spy.DeviceType.vulkan,
+    device_type=device_type,
 )
-module = spy.Module.load_from_file(app.device, "neural-demo.slang")
+link_module = app.device.load_module(
+    "neural-demo-wave.slang" if args.vector_type == "wave" else "neural-demo-inline.slang"
+)
+module = spy.Module.load_from_file(app.device, "neural-demo.slang", link=[link_module])
 image = spy.Tensor.load_from_image(
     app.device, Path(__file__).parent.joinpath("slangstars.png"), linearize=True
 )

--- a/examples/neural_slang_demo/neural-demo.py
+++ b/examples/neural_slang_demo/neural-demo.py
@@ -55,7 +55,8 @@ class Network(spy.InstanceList):
         self._params = spy.Tensor.from_numpy(app.device, params_np)
         self._params_grad = spy.Tensor.zeros_like(self._params)
         self._m, self._v = spy.Tensor.zeros_like(self._params), spy.Tensor.zeros_like(self._params)
-        self.params, self.params_grad = self._params.storage, self._params_grad.storage
+        self.params = self._params.storage.descriptor_handle_rw
+        self.params_grad = self._params_grad.storage.descriptor_handle_rw
         self.latent_texture = LatentTexture(32, 32, 4)
 
     def optimize(self, lr: float, it: int):

--- a/examples/neural_slang_demo/neural-demo.py
+++ b/examples/neural_slang_demo/neural-demo.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+from app import App
+import slangpy as spy
+import numpy as np
+from pathlib import Path
+
+app = App(
+    width=512 * 3 + 10 * 2,
+    height=512,
+    title="neural.slang demo",
+    device_type=spy.DeviceType.vulkan,
+)
+module = spy.Module.load_from_file(app.device, "neural-demo.slang")
+image = spy.Tensor.load_from_image(
+    app.device, Path(__file__).parent.joinpath("slangstars.png"), linearize=True
+)
+
+
+class LatentTexture(spy.InstanceList):
+    def __init__(self, width: int, height: int, num_latents: int):
+        super().__init__(module[f"LatentTexture<{num_latents}>"])
+        initial = np.random.uniform(0.0, 1.0, (height, width, num_latents)).astype("float32")
+        self._tex = spy.Tensor.from_numpy(app.device, initial)
+        self._tex_grad = spy.Tensor.zeros_like(self._tex)
+        self.texture, self.texture_grads = self._tex, self._tex_grad
+        self._m, self._v = spy.Tensor.zeros_like(self._tex), spy.Tensor.zeros_like(self._tex)
+
+    def optimize(self, lr: float, it: int):
+        module.optimizer_step(self._tex, self._tex_grad, self._m, self._v, lr, it)
+
+
+def xavier_init(layers):
+    params = []
+    for inp, out in layers:
+        scale = np.sqrt(6.0 / (inp + out))
+        params.extend([np.random.uniform(-scale, scale, out * inp), np.zeros(out)])
+    return np.concatenate(params).astype("float32")
+
+
+class Network(spy.InstanceList):
+    def __init__(self):
+        super().__init__(module["Network"])
+        params_np = xavier_init([(4, 32), (32, 32), (32, 3)])
+        self._params = spy.Tensor.from_numpy(app.device, params_np)
+        self._params_grad = spy.Tensor.zeros_like(self._params)
+        self._m, self._v = spy.Tensor.zeros_like(self._params), spy.Tensor.zeros_like(self._params)
+        self.params, self.params_grad = self._params.storage, self._params_grad.storage
+        self.latent_texture = LatentTexture(32, 32, 4)
+
+    def optimize(self, lr: float, it: int):
+        module.optimizer_step(self._params, self._params_grad, self._m, self._v, lr, it)
+        self.latent_texture.optimize(lr, it)
+
+
+network = Network()
+iteration = 0
+res, batch_size, lr = spy.int2(256, 256), (64, 64), 0.001
+
+print("Compiling shaders...")
+
+while app.process_events():
+    app.blit(image, size=spy.int2(512), offset=spy.int2(0, 0), tonemap=False, bilinear=True)
+
+    output = spy.Tensor.empty_like(image)
+    module.render(pixel=spy.call_id(), resolution=res, network=network, _result=output)
+    app.blit(output, size=spy.int2(512), offset=spy.int2(522, 0), tonemap=False, bilinear=True)
+
+    loss_out = spy.Tensor.empty_like(image)
+    module.show_loss(
+        pixel=spy.call_id(), resolution=res, network=network, reference=image, _result=loss_out
+    )
+    app.blit(loss_out, size=spy.int2(512), offset=spy.int2(1044, 0), tonemap=False)
+
+    for _ in range(20):
+        module.calculate_grads(
+            seed=spy.wang_hash(seed=iteration, warmup=2),
+            batch_index=spy.grid(batch_size),
+            batch_size=spy.int2(batch_size),
+            reference=image,
+            network=network,
+        )
+        iteration += 1
+        network.optimize(lr, iteration)
+
+    print(f"Loss: {np.mean(loss_out.to_numpy()):.5f}")
+    app.present()

--- a/examples/neural_slang_demo/neural-demo.slang
+++ b/examples/neural_slang_demo/neural-demo.slang
@@ -18,23 +18,17 @@ typealias Layer0 = FFLayer<float, InputVec, HiddenVec, LinearLayout, LeakyReLU<f
 typealias Layer1 = FFLayer<float, HiddenVec, HiddenVec, LinearLayout, LeakyReLU<float>, true>;
 typealias Layer2 = FFLayer<float, HiddenVec, OutputVec, LinearLayout, ExpActivation<float>, true>;
 
-static const uint TOTAL_PARAMS = Layer0.ParameterCount + Layer1.ParameterCount + Layer2.ParameterCount;
-
-// Workaround: getOffset is not yet differentiable, so we pass per-layer addresses
-// instead of computing offsets inside the differentiable function.
+// WAR(https://github.com/shader-slang/slang/issues/10195): getOffset is not yet differentiable, so we pass per-layer addresses.
 [Differentiable]
-OutputVec mlp_forward(Address w0, Address b0, Address w1, Address b1, Address w2, Address b2, InputVec input)
+float3 mlp_forward(Address w0, Address b0, Address w1, Address b1, Address w2, Address b2, InputVec input)
 {
     let h0 = Layer0(LeakyReLU<float>(LEAKY_RELU_SLOPE)).eval<Address>(input, w0, b0);
     let h1 = Layer1(LeakyReLU<float>(LEAKY_RELU_SLOPE)).eval<Address>(h0, w1, b1);
-    return Layer2(ExpActivation<float>()).eval<Address>(h1, w2, b2);
+    return outputToFloat3(Layer2(ExpActivation<float>()).eval<Address>(h1, w2, b2));
 }
 
-// Compute per-layer weight/bias addresses from a base address (non-differentiable).
-void getLayerAddresses(Address base,
-    out Address w0, out Address b0,
-    out Address w1, out Address b1,
-    out Address w2, out Address b2)
+void getLayerAddresses(Address base, out Address w0, out Address b0,
+    out Address w1, out Address b1, out Address w2, out Address b2)
 {
     int offset = 0;
     w0 = base.getOffset(offset); b0 = base.getOffset(offset + INPUT_DIM * HIDDEN_DIM);
@@ -81,14 +75,6 @@ struct Network
 }
 
 [Differentiable]
-float3 eval(Address w0, Address b0, Address w1, Address b1, Address w2, Address b2,
-            LatentTexture<INPUT_DIM> tex, no_diff float2 uv)
-{
-    let out = mlp_forward(w0, b0, w1, b1, w2, b2, tex.sample(uv));
-    return outputToFloat3(out);
-}
-
-[Differentiable]
 float3 gamma_correct(float3 color) { return pow(color, 1.0f / 2.2f); }
 
 [Differentiable]
@@ -96,7 +82,7 @@ float3 loss(Address w0, Address b0, Address w1, Address b1, Address w2, Address 
             LatentTexture<INPUT_DIM> tex, no_diff int2 pixel, no_diff int2 resolution, no_diff float3 reference)
 {
     float2 uv = (float2(pixel) + 0.5f) / float2(resolution);
-    float3 error = gamma_correct(eval(w0, b0, w1, b1, w2, b2, tex, uv)) - gamma_correct(reference);
+    float3 error = gamma_correct(mlp_forward(w0, b0, w1, b1, w2, b2, tex.sample(uv))) - gamma_correct(reference);
     return error * error;
 }
 
@@ -113,7 +99,7 @@ float3 render(int2 pixel, int2 resolution, Network network)
     Address w0, b0, w1, b1, w2, b2;
     getLayerAddresses(Address(network.params), w0, b0, w1, b1, w2, b2);
     float2 uv = (float2(pixel) + 0.5f) / float2(resolution);
-    return eval(w0, b0, w1, b1, w2, b2, network.latent_texture, uv);
+    return mlp_forward(w0, b0, w1, b1, w2, b2, network.latent_texture.sample(uv));
 }
 
 // Wrapper for visualization - calls loss() without gradients

--- a/examples/neural_slang_demo/neural-demo.slang
+++ b/examples/neural_slang_demo/neural-demo.slang
@@ -10,23 +10,24 @@ static const float LEAKY_RELU_SLOPE = 0.01f;
 extern struct InputVec : IVector<float>;
 extern struct HiddenVec : IVector<float>;
 extern struct OutputVec : IVector<float>;
+extern float3 outputToFloat3(OutputVec v);
 
-typealias Storage = StructuredBufferStorage<float>;
-typealias Layer0 = FFLayer<float, InputVec, HiddenVec, Storage, LinearLayout, LeakyReLU<float>, true>;
-typealias Layer1 = FFLayer<float, HiddenVec, HiddenVec, Storage, LinearLayout, LeakyReLU<float>, true>;
-typealias Layer2 = FFLayer<float, HiddenVec, OutputVec, Storage, LinearLayout, ExpActivation<float>, true>;
+typealias Address = BindlessAddress<float>;
+typealias Layer0 = FFLayer<float, InputVec, HiddenVec, LinearLayout, LeakyReLU<float>, true>;
+typealias Layer1 = FFLayer<float, HiddenVec, HiddenVec, LinearLayout, LeakyReLU<float>, true>;
+typealias Layer2 = FFLayer<float, HiddenVec, OutputVec, LinearLayout, ExpActivation<float>, true>;
 
 static const uint TOTAL_PARAMS = Layer0.ParameterCount + Layer1.ParameterCount + Layer2.ParameterCount;
 
 [Differentiable]
-OutputVec mlp_forward(Storage storage, InputVec input)
+OutputVec mlp_forward(Address addr, InputVec input)
 {
-    uint addr = 0u;
-    let h0 = Layer0(addr, addr + INPUT_DIM * HIDDEN_DIM, LeakyReLU<float>(LEAKY_RELU_SLOPE)).eval<Storage>(storage, input);
-    addr = Layer0.nextAddress(addr);
-    let h1 = Layer1(addr, addr + HIDDEN_DIM * HIDDEN_DIM, LeakyReLU<float>(LEAKY_RELU_SLOPE)).eval<Storage>(storage, h0);
-    addr = Layer1.nextAddress(addr);
-    return Layer2(addr, addr + HIDDEN_DIM * OUTPUT_DIM, ExpActivation<float>()).eval<Storage>(storage, h1);
+    int offset = 0;
+    let h0 = Layer0(LeakyReLU<float>(LEAKY_RELU_SLOPE)).eval<Address>(input, addr.getOffset(offset), addr.getOffset(offset + INPUT_DIM * HIDDEN_DIM));
+    offset = Layer0.nextOffset(offset);
+    let h1 = Layer1(LeakyReLU<float>(LEAKY_RELU_SLOPE)).eval<Address>(h0, addr.getOffset(offset), addr.getOffset(offset + HIDDEN_DIM * HIDDEN_DIM));
+    offset = Layer1.nextOffset(offset);
+    return Layer2(ExpActivation<float>()).eval<Address>(h1, addr.getOffset(offset), addr.getOffset(offset + HIDDEN_DIM * OUTPUT_DIM));
 }
 
 struct LatentTexture<let N : int>
@@ -49,37 +50,37 @@ struct LatentTexture<let N : int>
         int2 c1 = min(c0 + 1, size - 1);
         float2 f = saturate(uv - float2(c0));
 
-        InputVec result;
+        float data[N];
         [ForceUnroll]
         for (int i = 0; i < N; ++i)
-            result[i] = lerp(lerp(getLatent(c0.x, c0.y, i), getLatent(c1.x, c0.y, i), f.x),
-                             lerp(getLatent(c0.x, c1.y, i), getLatent(c1.x, c1.y, i), f.x), f.y);
-        return result;
+            data[i] = lerp(lerp(getLatent(c0.x, c0.y, i), getLatent(c1.x, c0.y, i), f.x),
+                           lerp(getLatent(c0.x, c1.y, i), getLatent(c1.x, c1.y, i), f.x), f.y);
+        return InputVec(data);
     }
 }
 
 struct Network
 {
     LatentTexture<INPUT_DIM> latent_texture;
-    RWStructuredBuffer<float> params;
-    RWStructuredBuffer<float> params_grad;
+    RWStructuredBuffer<float>.Handle params;
+    RWStructuredBuffer<float>.Handle params_grad;
 }
 
 [Differentiable]
-float3 eval(Storage storage, LatentTexture<INPUT_DIM> tex, no_diff float2 uv)
+float3 eval(Address addr, LatentTexture<INPUT_DIM> tex, no_diff float2 uv)
 {
-    let out = mlp_forward(storage, tex.sample(uv));
-    return float3(out[0], out[1], out[2]);
+    let out = mlp_forward(addr, tex.sample(uv));
+    return outputToFloat3(out);
 }
 
 [Differentiable]
 float3 gamma_correct(float3 color) { return pow(color, 1.0f / 2.2f); }
 
 [Differentiable]
-float3 loss(Storage storage, LatentTexture<INPUT_DIM> tex, no_diff int2 pixel, no_diff int2 resolution, no_diff float3 reference)
+float3 loss(Address addr, LatentTexture<INPUT_DIM> tex, no_diff int2 pixel, no_diff int2 resolution, no_diff float3 reference)
 {
     float2 uv = (float2(pixel) + 0.5f) / float2(resolution);
-    float3 error = gamma_correct(eval(storage, tex, uv)) - gamma_correct(reference);
+    float3 error = gamma_correct(eval(addr, tex, uv)) - gamma_correct(reference);
     return error * error;
 }
 
@@ -94,13 +95,13 @@ struct LCG
 float3 render(int2 pixel, int2 resolution, Network network)
 {
     float2 uv = (float2(pixel) + 0.5f) / float2(resolution);
-    return eval(Storage(network.params), network.latent_texture, uv);
+    return eval(Address(network.params), network.latent_texture, uv);
 }
 
 // Wrapper for visualization - calls loss() without gradients
 float3 show_loss(int2 pixel, int2 resolution, float3 reference, Network network)
 {
-    return loss(Storage(network.params), network.latent_texture, pixel, resolution, reference);
+    return loss(Address(network.params), network.latent_texture, pixel, resolution, reference);
 }
 
 void calculate_grads(uint seed, int2 batch_index, int2 batch_size, Tensor<float3, 2> reference, Network network)
@@ -111,8 +112,8 @@ void calculate_grads(uint seed, int2 batch_index, int2 batch_size, Tensor<float3
     int2 pixel = int2(uv * float2(resolution));
     float3 ref_color = reference.getv(pixel);
 
-    let storage_pair = DifferentialPtrPair<Storage>(Storage(network.params), Storage(network.params_grad));
-    bwd_diff(loss)(storage_pair, network.latent_texture, pixel, resolution, ref_color, float3(1.0f));
+    let addr_pair = DifferentialPtrPair<Address>(Address(network.params), Address(network.params_grad));
+    bwd_diff(loss)(addr_pair, network.latent_texture, pixel, resolution, ref_color, float3(1.0f));
 }
 
 void optimizer_step(inout float primal, inout float grad, inout float mean, inout float variance, float lr, int iter)

--- a/examples/neural_slang_demo/neural-demo.slang
+++ b/examples/neural_slang_demo/neural-demo.slang
@@ -8,13 +8,13 @@ static const int OUTPUT_DIM = 3;
 static const float LEAKY_RELU_SLOPE = 0.01f;
 
 typealias InputVec = InlineVector<float, INPUT_DIM>;
-typealias HiddenVec = InlineVector<float, HIDDEN_DIM>;
+extern struct HiddenVec : IVector<float>;
 typealias OutputVec = InlineVector<float, OUTPUT_DIM>;
 
 typealias Storage = StructuredBufferStorage<float>;
-typealias Layer0 = FFLayer<float, InputVec, HiddenVec, Storage, LinearLayout, LeakyReLU<float>>;
-typealias Layer1 = FFLayer<float, HiddenVec, HiddenVec, Storage, LinearLayout, LeakyReLU<float>>;
-typealias Layer2 = FFLayer<float, HiddenVec, OutputVec, Storage, LinearLayout, ExpActivation<float>>;
+typealias Layer0 = FFLayer<float, InputVec, HiddenVec, Storage, LinearLayout, LeakyReLU<float>, true>;
+typealias Layer1 = FFLayer<float, HiddenVec, HiddenVec, Storage, LinearLayout, LeakyReLU<float>, true>;
+typealias Layer2 = FFLayer<float, HiddenVec, OutputVec, Storage, LinearLayout, ExpActivation<float>, true>;
 
 static const uint TOTAL_PARAMS = Layer0.ParameterCount + Layer1.ParameterCount + Layer2.ParameterCount;
 

--- a/examples/neural_slang_demo/neural-demo.slang
+++ b/examples/neural_slang_demo/neural-demo.slang
@@ -7,9 +7,9 @@ static const int HIDDEN_DIM = 32;
 static const int OUTPUT_DIM = 3;
 static const float LEAKY_RELU_SLOPE = 0.01f;
 
-typealias InputVec = InlineVector<float, INPUT_DIM>;
+extern struct InputVec : IVector<float>;
 extern struct HiddenVec : IVector<float>;
-typealias OutputVec = InlineVector<float, OUTPUT_DIM>;
+extern struct OutputVec : IVector<float>;
 
 typealias Storage = StructuredBufferStorage<float>;
 typealias Layer0 = FFLayer<float, InputVec, HiddenVec, Storage, LinearLayout, LeakyReLU<float>, true>;
@@ -41,7 +41,7 @@ struct LatentTexture<let N : int>
     void getLatentBwd(int x, int y, int idx, float grad) { texture_grads.set({y, x, idx}, grad); }
 
     [Differentiable]
-    InlineVector<float, N> sample(no_diff inout float2 uv)
+    InputVec sample(no_diff inout float2 uv)
     {
         int2 size = int2(texture.shape[1], texture.shape[0]);
         uv *= float2(size - 1);
@@ -49,7 +49,7 @@ struct LatentTexture<let N : int>
         int2 c1 = min(c0 + 1, size - 1);
         float2 f = saturate(uv - float2(c0));
 
-        InlineVector<float, N> result;
+        InputVec result;
         [ForceUnroll]
         for (int i = 0; i < N; ++i)
             result[i] = lerp(lerp(getLatent(c0.x, c0.y, i), getLatent(c1.x, c0.y, i), f.x),

--- a/examples/neural_slang_demo/neural-demo.slang
+++ b/examples/neural_slang_demo/neural-demo.slang
@@ -10,7 +10,8 @@ static const float LEAKY_RELU_SLOPE = 0.01f;
 extern struct InputVec : IVector<float>;
 extern struct HiddenVec : IVector<float>;
 extern struct OutputVec : IVector<float>;
-extern float3 outputToFloat3(OutputVec v);
+[Differentiable] extern InputVec arrayToInputVec(float data[INPUT_DIM]);
+[Differentiable] extern float3 outputToFloat3(OutputVec v);
 
 typealias Address = BindlessAddress<float>;
 typealias Layer0 = FFLayer<float, InputVec, HiddenVec, LinearLayout, LeakyReLU<float>, true>;
@@ -19,15 +20,28 @@ typealias Layer2 = FFLayer<float, HiddenVec, OutputVec, LinearLayout, ExpActivat
 
 static const uint TOTAL_PARAMS = Layer0.ParameterCount + Layer1.ParameterCount + Layer2.ParameterCount;
 
+// Workaround: getOffset is not yet differentiable, so we pass per-layer addresses
+// instead of computing offsets inside the differentiable function.
 [Differentiable]
-OutputVec mlp_forward(Address addr, InputVec input)
+OutputVec mlp_forward(Address w0, Address b0, Address w1, Address b1, Address w2, Address b2, InputVec input)
+{
+    let h0 = Layer0(LeakyReLU<float>(LEAKY_RELU_SLOPE)).eval<Address>(input, w0, b0);
+    let h1 = Layer1(LeakyReLU<float>(LEAKY_RELU_SLOPE)).eval<Address>(h0, w1, b1);
+    return Layer2(ExpActivation<float>()).eval<Address>(h1, w2, b2);
+}
+
+// Compute per-layer weight/bias addresses from a base address (non-differentiable).
+void getLayerAddresses(Address base,
+    out Address w0, out Address b0,
+    out Address w1, out Address b1,
+    out Address w2, out Address b2)
 {
     int offset = 0;
-    let h0 = Layer0(LeakyReLU<float>(LEAKY_RELU_SLOPE)).eval<Address>(input, addr.getOffset(offset), addr.getOffset(offset + INPUT_DIM * HIDDEN_DIM));
+    w0 = base.getOffset(offset); b0 = base.getOffset(offset + INPUT_DIM * HIDDEN_DIM);
     offset = Layer0.nextOffset(offset);
-    let h1 = Layer1(LeakyReLU<float>(LEAKY_RELU_SLOPE)).eval<Address>(h0, addr.getOffset(offset), addr.getOffset(offset + HIDDEN_DIM * HIDDEN_DIM));
+    w1 = base.getOffset(offset); b1 = base.getOffset(offset + HIDDEN_DIM * HIDDEN_DIM);
     offset = Layer1.nextOffset(offset);
-    return Layer2(ExpActivation<float>()).eval<Address>(h1, addr.getOffset(offset), addr.getOffset(offset + HIDDEN_DIM * OUTPUT_DIM));
+    w2 = base.getOffset(offset); b2 = base.getOffset(offset + HIDDEN_DIM * OUTPUT_DIM);
 }
 
 struct LatentTexture<let N : int>
@@ -50,12 +64,12 @@ struct LatentTexture<let N : int>
         int2 c1 = min(c0 + 1, size - 1);
         float2 f = saturate(uv - float2(c0));
 
-        float data[N];
+        float data[INPUT_DIM];
         [ForceUnroll]
         for (int i = 0; i < N; ++i)
             data[i] = lerp(lerp(getLatent(c0.x, c0.y, i), getLatent(c1.x, c0.y, i), f.x),
                            lerp(getLatent(c0.x, c1.y, i), getLatent(c1.x, c1.y, i), f.x), f.y);
-        return InputVec(data);
+        return arrayToInputVec(data);
     }
 }
 
@@ -67,9 +81,10 @@ struct Network
 }
 
 [Differentiable]
-float3 eval(Address addr, LatentTexture<INPUT_DIM> tex, no_diff float2 uv)
+float3 eval(Address w0, Address b0, Address w1, Address b1, Address w2, Address b2,
+            LatentTexture<INPUT_DIM> tex, no_diff float2 uv)
 {
-    let out = mlp_forward(addr, tex.sample(uv));
+    let out = mlp_forward(w0, b0, w1, b1, w2, b2, tex.sample(uv));
     return outputToFloat3(out);
 }
 
@@ -77,10 +92,11 @@ float3 eval(Address addr, LatentTexture<INPUT_DIM> tex, no_diff float2 uv)
 float3 gamma_correct(float3 color) { return pow(color, 1.0f / 2.2f); }
 
 [Differentiable]
-float3 loss(Address addr, LatentTexture<INPUT_DIM> tex, no_diff int2 pixel, no_diff int2 resolution, no_diff float3 reference)
+float3 loss(Address w0, Address b0, Address w1, Address b1, Address w2, Address b2,
+            LatentTexture<INPUT_DIM> tex, no_diff int2 pixel, no_diff int2 resolution, no_diff float3 reference)
 {
     float2 uv = (float2(pixel) + 0.5f) / float2(resolution);
-    float3 error = gamma_correct(eval(addr, tex, uv)) - gamma_correct(reference);
+    float3 error = gamma_correct(eval(w0, b0, w1, b1, w2, b2, tex, uv)) - gamma_correct(reference);
     return error * error;
 }
 
@@ -94,14 +110,18 @@ struct LCG
 
 float3 render(int2 pixel, int2 resolution, Network network)
 {
+    Address w0, b0, w1, b1, w2, b2;
+    getLayerAddresses(Address(network.params), w0, b0, w1, b1, w2, b2);
     float2 uv = (float2(pixel) + 0.5f) / float2(resolution);
-    return eval(Address(network.params), network.latent_texture, uv);
+    return eval(w0, b0, w1, b1, w2, b2, network.latent_texture, uv);
 }
 
 // Wrapper for visualization - calls loss() without gradients
 float3 show_loss(int2 pixel, int2 resolution, float3 reference, Network network)
 {
-    return loss(Address(network.params), network.latent_texture, pixel, resolution, reference);
+    Address w0, b0, w1, b1, w2, b2;
+    getLayerAddresses(Address(network.params), w0, b0, w1, b1, w2, b2);
+    return loss(w0, b0, w1, b1, w2, b2, network.latent_texture, pixel, resolution, reference);
 }
 
 void calculate_grads(uint seed, int2 batch_index, int2 batch_size, Tensor<float3, 2> reference, Network network)
@@ -112,8 +132,17 @@ void calculate_grads(uint seed, int2 batch_index, int2 batch_size, Tensor<float3
     int2 pixel = int2(uv * float2(resolution));
     float3 ref_color = reference.getv(pixel);
 
-    let addr_pair = DifferentialPtrPair<Address>(Address(network.params), Address(network.params_grad));
-    bwd_diff(loss)(addr_pair, network.latent_texture, pixel, resolution, ref_color, float3(1.0f));
+    // Build per-layer DifferentialPtrPairs (primal=params, differential=grads).
+    Address pw0, pb0, pw1, pb1, pw2, pb2;
+    getLayerAddresses(Address(network.params), pw0, pb0, pw1, pb1, pw2, pb2);
+    Address gw0, gb0, gw1, gb1, gw2, gb2;
+    getLayerAddresses(Address(network.params_grad), gw0, gb0, gw1, gb1, gw2, gb2);
+
+    bwd_diff(loss)(
+        DifferentialPtrPair<Address>(pw0, gw0), DifferentialPtrPair<Address>(pb0, gb0),
+        DifferentialPtrPair<Address>(pw1, gw1), DifferentialPtrPair<Address>(pb1, gb1),
+        DifferentialPtrPair<Address>(pw2, gw2), DifferentialPtrPair<Address>(pb2, gb2),
+        network.latent_texture, pixel, resolution, ref_color, float3(1.0f));
 }
 
 void optimizer_step(inout float primal, inout float grad, inout float mean, inout float variance, float lr, int iter)

--- a/examples/neural_slang_demo/neural-demo.slang
+++ b/examples/neural_slang_demo/neural-demo.slang
@@ -12,9 +12,9 @@ typealias HiddenVec = InlineVector<float, HIDDEN_DIM>;
 typealias OutputVec = InlineVector<float, OUTPUT_DIM>;
 
 typealias Storage = StructuredBufferStorage<float>;
-typealias Layer0 = FFLayer<float, InputVec, HiddenVec, Storage, LeakyReLU<float>, true>;
-typealias Layer1 = FFLayer<float, HiddenVec, HiddenVec, Storage, LeakyReLU<float>, true>;
-typealias Layer2 = FFLayer<float, HiddenVec, OutputVec, Storage, ExpActivation<float>, true>;
+typealias Layer0 = FFLayer<float, InputVec, HiddenVec, Storage, LinearLayout, LeakyReLU<float>>;
+typealias Layer1 = FFLayer<float, HiddenVec, HiddenVec, Storage, LinearLayout, LeakyReLU<float>>;
+typealias Layer2 = FFLayer<float, HiddenVec, OutputVec, Storage, LinearLayout, ExpActivation<float>>;
 
 static const uint TOTAL_PARAMS = Layer0.ParameterCount + Layer1.ParameterCount + Layer2.ParameterCount;
 
@@ -52,8 +52,8 @@ struct LatentTexture<let N : int>
         InlineVector<float, N> result;
         [ForceUnroll]
         for (int i = 0; i < N; ++i)
-            result.set(i, lerp(lerp(getLatent(c0.x, c0.y, i), getLatent(c1.x, c0.y, i), f.x),
-                               lerp(getLatent(c0.x, c1.y, i), getLatent(c1.x, c1.y, i), f.x), f.y));
+            result[i] = lerp(lerp(getLatent(c0.x, c0.y, i), getLatent(c1.x, c0.y, i), f.x),
+                             lerp(getLatent(c0.x, c1.y, i), getLatent(c1.x, c1.y, i), f.x), f.y);
         return result;
     }
 }
@@ -69,7 +69,7 @@ struct Network
 float3 eval(Storage storage, LatentTexture<INPUT_DIM> tex, no_diff float2 uv)
 {
     let out = mlp_forward(storage, tex.sample(uv));
-    return float3(out.get(0), out.get(1), out.get(2));
+    return float3(out[0], out[1], out[2]);
 }
 
 [Differentiable]

--- a/examples/neural_slang_demo/neural-demo.slang
+++ b/examples/neural_slang_demo/neural-demo.slang
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+import slangpy;
+import neural;
+
+static const int INPUT_DIM = 4;
+static const int HIDDEN_DIM = 32;
+static const int OUTPUT_DIM = 3;
+static const float LEAKY_RELU_SLOPE = 0.01f;
+
+typealias InputVec = InlineVector<float, INPUT_DIM>;
+typealias HiddenVec = InlineVector<float, HIDDEN_DIM>;
+typealias OutputVec = InlineVector<float, OUTPUT_DIM>;
+
+typealias Storage = StructuredBufferStorage<float>;
+typealias Layer0 = FFLayer<float, InputVec, HiddenVec, Storage, LeakyReLU<float>, true>;
+typealias Layer1 = FFLayer<float, HiddenVec, HiddenVec, Storage, LeakyReLU<float>, true>;
+typealias Layer2 = FFLayer<float, HiddenVec, OutputVec, Storage, ExpActivation<float>, true>;
+
+static const uint TOTAL_PARAMS = Layer0.ParameterCount + Layer1.ParameterCount + Layer2.ParameterCount;
+
+[Differentiable]
+OutputVec mlp_forward(Storage storage, InputVec input)
+{
+    uint addr = 0u;
+    let h0 = Layer0(addr, addr + INPUT_DIM * HIDDEN_DIM, LeakyReLU<float>(LEAKY_RELU_SLOPE)).eval<Storage>(storage, input);
+    addr = Layer0.nextAddress(addr);
+    let h1 = Layer1(addr, addr + HIDDEN_DIM * HIDDEN_DIM, LeakyReLU<float>(LEAKY_RELU_SLOPE)).eval<Storage>(storage, h0);
+    addr = Layer1.nextAddress(addr);
+    return Layer2(addr, addr + HIDDEN_DIM * OUTPUT_DIM, ExpActivation<float>()).eval<Storage>(storage, h1);
+}
+
+struct LatentTexture<let N : int>
+{
+    Tensor<float, 3> texture;
+    AtomicTensor<float, 3> texture_grads;
+
+    [Differentiable]
+    float getLatent(int x, int y, int idx) { return texture[y, x, idx]; }
+
+    [BackwardDerivativeOf(getLatent)]
+    void getLatentBwd(int x, int y, int idx, float grad) { texture_grads.set({y, x, idx}, grad); }
+
+    [Differentiable]
+    InlineVector<float, N> sample(no_diff inout float2 uv)
+    {
+        int2 size = int2(texture.shape[1], texture.shape[0]);
+        uv *= float2(size - 1);
+        int2 c0 = clamp(int2(uv), int2(0), size - 1);
+        int2 c1 = min(c0 + 1, size - 1);
+        float2 f = saturate(uv - float2(c0));
+
+        InlineVector<float, N> result;
+        [ForceUnroll]
+        for (int i = 0; i < N; ++i)
+            result.set(i, lerp(lerp(getLatent(c0.x, c0.y, i), getLatent(c1.x, c0.y, i), f.x),
+                               lerp(getLatent(c0.x, c1.y, i), getLatent(c1.x, c1.y, i), f.x), f.y));
+        return result;
+    }
+}
+
+struct Network
+{
+    LatentTexture<INPUT_DIM> latent_texture;
+    RWStructuredBuffer<float> params;
+    RWStructuredBuffer<float> params_grad;
+}
+
+[Differentiable]
+float3 eval(Storage storage, LatentTexture<INPUT_DIM> tex, no_diff float2 uv)
+{
+    let out = mlp_forward(storage, tex.sample(uv));
+    return float3(out.get(0), out.get(1), out.get(2));
+}
+
+[Differentiable]
+float3 gamma_correct(float3 color) { return pow(color, 1.0f / 2.2f); }
+
+[Differentiable]
+float3 loss(Storage storage, LatentTexture<INPUT_DIM> tex, no_diff int2 pixel, no_diff int2 resolution, no_diff float3 reference)
+{
+    float2 uv = (float2(pixel) + 0.5f) / float2(resolution);
+    float3 error = gamma_correct(eval(storage, tex, uv)) - gamma_correct(reference);
+    return error * error;
+}
+
+struct LCG
+{
+    uint state;
+    __init(uint seed) { state = seed; }
+    [mutating] uint next_uint() { state = 1664525u * state + 1013904223u; return state; }
+    [mutating] float next_float() { return (next_uint() >> 8) * 0x1p-24; }
+}
+
+float3 render(int2 pixel, int2 resolution, Network network)
+{
+    float2 uv = (float2(pixel) + 0.5f) / float2(resolution);
+    return eval(Storage(network.params), network.latent_texture, uv);
+}
+
+// Wrapper for visualization - calls loss() without gradients
+float3 show_loss(int2 pixel, int2 resolution, float3 reference, Network network)
+{
+    return loss(Storage(network.params), network.latent_texture, pixel, resolution, reference);
+}
+
+void calculate_grads(uint seed, int2 batch_index, int2 batch_size, Tensor<float3, 2> reference, Network network)
+{
+    LCG lcg = LCG(seed);
+    float2 uv = (batch_index + float2(lcg.next_float(), lcg.next_float())) / float2(batch_size);
+    int2 resolution = int2(reference.shape[1], reference.shape[0]);
+    int2 pixel = int2(uv * float2(resolution));
+    float3 ref_color = reference.getv(pixel);
+
+    let storage_pair = DifferentialPtrPair<Storage>(Storage(network.params), Storage(network.params_grad));
+    bwd_diff(loss)(storage_pair, network.latent_texture, pixel, resolution, ref_color, float3(1.0f));
+}
+
+void optimizer_step(inout float primal, inout float grad, inout float mean, inout float variance, float lr, int iter)
+{
+    const float BETA1 = 0.9f, BETA2 = 0.999f, EPSILON = 1e-8f;
+    mean = lerp(grad, mean, BETA1);
+    variance = lerp(grad * grad, variance, BETA2);
+    float m_hat = mean / (1.0f - pow(BETA1, iter));
+    float v_hat = variance / (1.0f - pow(BETA2, iter));
+    primal -= lr * m_hat / (sqrt(v_hat) + EPSILON);
+    grad = 0.0f;
+}

--- a/examples/neural_slang_demo/screenshot.png
+++ b/examples/neural_slang_demo/screenshot.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:85418946a5e96ef3ac3f43bff0b6fc3e3460392eba3e2174c567ce0b8337f15f
+size 479785

--- a/examples/neural_slang_demo/slangstars.png
+++ b/examples/neural_slang_demo/slangstars.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:92250d04272c29f5b28b5b72c988aa0cbb367f2144fc7c0dbd60cc6e493db0fa
+size 30996


### PR DESCRIPTION
# Neural Demo - Using neural.slang

This demo showcases how to use Slang's `neural.slang` standard module to build a neural network for image reconstruction. This is a re-creation of the texture example in the https://github.com/shader-slang/neural-shading-s25 course.

## neural.slang Types Used

| Type | Description |
|------|-------------|
| `InlineVector<T, N>` | Fixed-size vector type with compile-time `.Size` constant |
| `StructuredBufferStorage<T>` | GPU buffer storage implementing `IStorage<T>` interface |
| `FFLayer<T, InVec, OutVec, Storage, Activation, HasBias>` | Feed-forward neural network layer |
| `IdentityActivation<T>` | Pass-through activation (no transformation) |
| `NoParam()` | Empty parameter for activations that don't need configuration |

## Before/After Comparison

This section shows the comparison between the original code and the code with the neural.slang APIs

### Lines of Code

Approximate lines of code comparison apart from comments.

| File Type | Original | neural.slang |
|-----------|----------|--------------|
| Slang | 171 | 105 |
| Python | 103 | 68 |

### Vector Types

| Before (Manual) | After (neural.slang) |
|-----------------|---------------------|
| `float[4]` / `float4` | `InlineVector<float, 4>` |
| `float[32]` | `InlineVector<float, 32>` |
| `float[3]` / `float3` | `InlineVector<float, 3>` |
| Manual size tracking | `Vec4.Size` compile-time constant |

### Parameter Storage

| Before (Manual) | After (neural.slang) |
|-----------------|---------------------|
| Separate weight/bias buffers | `StructuredBufferStorage<T>` wrapper |
| Manual offset calculation | `Storage.getOffset()` method |
| Manual parameter count | `FFLayer.ParameterCount` constant |

### Layer Forward Pass

| Before (Manual) | After (neural.slang) |
|-----------------|---------------------|
| Manual matrix multiply | `FFLayer.eval()` using `linearTransform` |
| Explicit loops | Optimized internal implementation |
| Manual bias addition | Handled by `FFLayer` |

**Before:**
```slang
// Single layer forward pass
[Differentiable]
float[Outputs] forward(float[Inputs] x)
{
    float[Outputs] y;
    [MaxIters(Outputs)]
    for (int row = 0; row < Outputs; ++row)
    {
        var sum = get_bias(row);
        [ForceUnroll]
        for (int col = 0; col < Inputs; ++col)
            sum += get_weight(row, col) * x[col];
        y[row] = sum;
    }
    return y;
}

// Network evaluation with manual activation loops
[Differentiable]
float3 eval(no_diff float2 uv)
{
    float encoded_inputs[NumLatents] = latent_texture.sample(uv);

    float output0[32] = layer0.forward(encoded_inputs);
    [ForceUnroll]
    for (int i = 0; i < 32; ++i)
        output0[i] = leakyReLU(output0[i]);
    float output1[32] = layer1.forward(output0);
    [ForceUnroll]
    for (int i = 0; i < 32; ++i)
        output1[i] = leakyReLU(output1[i]);
    float output2[3] = layer2.forward(output1);
    [ForceUnroll]
    for (int i = 0; i < 3; ++i)
        output2[i] = exp(output2[i]);
    return float3(output2[0], output2[1], output2[2]);
}
```

**After:**
```slang
// Network evaluation with FFLayer and built-in activations
[Differentiable]
OutputVec mlp_forward(Storage storage, InputVec input)
{
    uint addr = 0u;
    let h0 = Layer0(addr, addr + INPUT_DIM * HIDDEN_DIM, LeakyReLU<float>(LEAKY_RELU_SLOPE)).eval<Storage>(storage, input);
    addr = Layer0.nextAddress(addr);
    let h1 = Layer1(addr, addr + HIDDEN_DIM * HIDDEN_DIM, LeakyReLU<float>(LEAKY_RELU_SLOPE)).eval<Storage>(storage, h0);
    addr = Layer1.nextAddress(addr);
    return Layer2(addr, addr + HIDDEN_DIM * OUTPUT_DIM, ExpActivation<float>()).eval<Storage>(storage, h1);
}
```

### Network Definition

| Before (Manual) | After (neural.slang) |
|-----------------|---------------------|
| Custom struct with manual layout | Type aliases for layers |
| Hardcoded dimensions | Dimensions from vector types |
| Manual weight indexing | Automatic address calculation |

## Running the Demo

```bash
cd slangpy-samples/examples/neural-demo
python neural-demo.py
```

The demo displays three panels:
1. **Reference image** - Target to reconstruct
2. **Network output** - Current reconstruction using FFLayer-based network
3. **Loss visualization** - Per-pixel error

Loss values are printed to console and should decrease over time as the network learns.