### PR TITLE
Update neural demo screenshot with a converged result

### DIFF
--- a/examples/neural_slang_demo/screenshot.png
+++ b/examples/neural_slang_demo/screenshot.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:85418946a5e96ef3ac3f43bff0b6fc3e3460392eba3e2174c567ce0b8337f15f
-size 479785
+oid sha256:3cf984aa835c40fdc9ebb65323ea65070a98519afba847d45e58689390bf0314
+size 179418


### PR DESCRIPTION
Regenerates the neural demo's README figure from the ported demo (#51) trained to convergence - 20000 iterations with the WaveTangledVector variant, final mean loss ~9e-5. The reconstruction (middle panel) is now nearly indistinguishable from the reference, and the per-pixel loss panel shows only faint residual edges.

The image is composed offscreen with the same layout as the windowed demo: reference | network output | per-pixel loss, three 512px panels (bilinear-upscaled from the 256x256 tensors, sRGB-encoded like the in-app screenshot key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
