### PR TITLE
Add Metal support to neural UTracer

### DIFF
--- a/experiments/neural_slang/utracer/README.md
+++ b/experiments/neural_slang/utracer/README.md
@@ -67,8 +67,8 @@ The two entry points also compile different neural execution modes. `train.py`
 uses `ExecutionMode.Training` and sizes shared memory for the complete
 encoder/decoder network. Because `main.py` consumes baked latents, it uses
 `ExecutionMode.Inference` and sizes shared memory for only the decoder layers.
-On the Vulkan wave path this reduces the declared workgroup memory from 16 KiB
-to 3 KiB.
+On the wave path this reduces the declared workgroup memory from 16 KiB to
+3 KiB.
 
 Checkpoints remain portable row-major arrays. On the wave backend,
 `NetworkParameterLayoutConverter` converts the encoder and decoder separately
@@ -92,18 +92,31 @@ From the active SlangPy virtual environment:
 python -m pip install -r utracer/requirements.txt
 ```
 
-`slang.neural` is experimental in the current Slang release. `common.py`
-enables the required compiler feature automatically. The sample uses Vulkan
-because the same device must support pointers, cooperative matrices, and ray
-queries.
+`slang.neural` is experimental. `common.py` enables the required compiler
+feature automatically. Metal currently requires a Slang ToT build containing
+[`b64d495d9`](https://github.com/shader-slang/slang/commit/b64d495d93aa9484aeec0e5724e895d12e269c4e)
+or later; that change makes vector subscript accessors differentiable. Build
+SlangPy against that local Slang tree with `SGL_LOCAL_SLANG=ON` so that both
+the compiler library and `neural.slang-module` come from ToT.
 
 ### Backend support
 
-The two entry points currently require Vulkan. CUDA is not supported
-end-to-end: UTracer's compute path uses `TraceRayInline`, and the ceramic MDL
-teacher uses `Texture.SampleLevel`; neither feature is available to these
-generated kernels on the CUDA compute target. The neural model itself is not
-the blocker, but both `main.py` and `train.py` depend on one of those stages.
+| Workflow | Vulkan | Metal | CUDA |
+|---|---|---|---|
+| Inline inference | Yes | Yes | No |
+| Wave inference | Cooperative-matrix device required | Yes, using `simdgroup_matrix` | No |
+| Inline training | Yes | Yes | No |
+| Wave training | Cooperative-matrix device required | Yes, using `simdgroup_matrix` | No |
+
+The default device is Metal on macOS and Vulkan elsewhere. Both Metal vector
+paths and a one-iteration wave training run were verified on an Apple M4 with
+Slang ToT `340a191c5d4686b10b54434a329760abf97a3ed5`.
+
+CUDA is not supported end-to-end: UTracer's compute path uses
+`TraceRayInline`, and the ceramic MDL teacher uses `Texture.SampleLevel`;
+neither feature is available to these generated kernels on the CUDA compute
+target. The neural model itself is not the blocker, but both `main.py` and
+`train.py` depend on one of those stages.
 
 ## Run a trained material
 
@@ -122,6 +135,15 @@ Use the cooperative-matrix-backed vector implementation with:
 ```bash
 python main.py \
   --vector-backend wave \
+  --checkpoint runs/20260710_103810/0016384
+```
+
+On macOS, Metal is selected automatically. It can also be requested
+explicitly for either vector backend:
+
+```bash
+python main.py \
+  --device-type metal --vector-backend wave \
   --checkpoint runs/20260710_103810/0016384
 ```
 
@@ -149,6 +171,12 @@ To exercise `WaveTangledVector` during both forward and backward passes:
 
 ```bash
 python train.py --vector-backend wave
+```
+
+The corresponding explicit Metal command is:
+
+```bash
+python train.py --device-type metal --vector-backend wave
 ```
 
 A small smoke run is useful before a full bake:
@@ -189,7 +217,9 @@ weights followed immediately by its bias:
 | Decoder 2 | 32 -> 3 | 12,296 | 99 |
 | Total | | | 12,395 |
 
-The wave backend converts that array to the 16-padded tiled optimal layout:
+The wave backend converts that array to its 16-padded target-optimal layout.
+Vulkan uses tiled cooperative-matrix weights; Metal uses the row-major layout
+expected by `simdgroup_matrix`:
 
 | Block | Portable floats | Optimal floats | Optimal offset |
 |---|---:|---:|---:|

--- a/experiments/neural_slang/utracer/common.py
+++ b/experiments/neural_slang/utracer/common.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 from typing import Literal
 
@@ -9,28 +10,42 @@ import slangpy as spy
 
 
 VectorBackend = Literal["inline", "wave"]
+DeviceBackend = Literal["vulkan", "metal"]
 NeuralExecutionMode = Literal["training", "inference"]
 HERE = Path(__file__).resolve().parent
+
+
+def default_device_backend() -> DeviceBackend:
+    return "metal" if sys.platform == "darwin" else "vulkan"
 
 
 def create_device(
     vector_backend: VectorBackend = "inline",
     *,
+    device_backend: DeviceBackend | None = None,
     execution_mode: NeuralExecutionMode = "inference",
 ) -> spy.Device:
-    """Create a Vulkan device specialized for neural training or inference."""
+    """Create a GPU device specialized for neural training or inference."""
     if vector_backend not in ("inline", "wave"):
         raise ValueError(f"Unknown vector backend: {vector_backend}")
+    if device_backend is None:
+        device_backend = default_device_backend()
+    if device_backend not in ("vulkan", "metal"):
+        raise ValueError(f"Unknown device backend: {device_backend}")
     if execution_mode not in ("training", "inference"):
         raise ValueError(f"Unknown neural execution mode: {execution_mode}")
 
     device = spy.Device(
-        type=spy.DeviceType.vulkan,
+        type={
+            "vulkan": spy.DeviceType.vulkan,
+            "metal": spy.DeviceType.metal,
+        }[device_backend],
         compiler_options={
             "include_paths": [spy.SHADER_PATH, HERE],
             "defines": {
                 "NEURAL_VECTOR_WAVE": "1" if vector_backend == "wave" else "0",
                 "NEURAL_TARGET_CUDA": "0",
+                "NEURAL_TARGET_METAL": "1" if device_backend == "metal" else "0",
                 "NEURAL_EXECUTION_INFERENCE": ("1" if execution_mode == "inference" else "0"),
             },
             "enable_experimental_features": True,
@@ -38,10 +53,16 @@ def create_device(
         enable_hot_reload=False,
     )
 
-    if vector_backend == "wave" and spy.Feature.cooperative_matrix not in device.features:
+    # Slang RHI currently exposes this feature bit for Vulkan cooperative-matrix
+    # extensions, while Metal lowers the same Slang capability to simdgroup_matrix.
+    if (
+        vector_backend == "wave"
+        and device_backend == "vulkan"
+        and spy.Feature.cooperative_matrix not in device.features
+    ):
         device.close()
         raise RuntimeError(
-            "The wave backend requires Vulkan cooperative-matrix support. "
+            f"The wave backend requires cooperative-matrix support on {device_backend}. "
             "Use --vector-backend inline on this device."
         )
     return device

--- a/experiments/neural_slang/utracer/main.py
+++ b/experiments/neural_slang/utracer/main.py
@@ -6,10 +6,22 @@ import argparse
 from pathlib import Path
 
 if __package__:
-    from .common import VectorBackend, create_device, require_wave_safe_work_size
+    from .common import (
+        DeviceBackend,
+        VectorBackend,
+        create_device,
+        default_device_backend,
+        require_wave_safe_work_size,
+    )
     from .renderer import Camera, MicroScene, Viewer, save_tonemapped
 else:
-    from common import VectorBackend, create_device, require_wave_safe_work_size
+    from common import (
+        DeviceBackend,
+        VectorBackend,
+        create_device,
+        default_device_backend,
+        require_wave_safe_work_size,
+    )
     from renderer import Camera, MicroScene, Viewer, save_tonemapped
 
 
@@ -20,6 +32,11 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run the neural-only UTracer.")
     parser.add_argument("--checkpoint", type=Path, required=True)
     parser.add_argument("--vector-backend", choices=("inline", "wave"), default="inline")
+    parser.add_argument(
+        "--device-type",
+        choices=("vulkan", "metal"),
+        default=default_device_backend(),
+    )
     parser.add_argument("--mesh", type=Path, default=HERE / "data/shaderball.glb")
     parser.add_argument(
         "--environment",
@@ -49,13 +66,19 @@ def main() -> None:
     if args.width < 1 or args.height < 1 or args.spp < 1 or args.frames < 0:
         raise ValueError("Image dimensions and spp must be positive; frames cannot be negative")
     backend: VectorBackend = args.vector_backend
+    device_backend: DeviceBackend = args.device_type
     require_wave_safe_work_size(backend, args.width * args.height, "render target")
 
-    device = create_device(backend, execution_mode="inference")
+    device = create_device(
+        backend,
+        device_backend=device_backend,
+        execution_mode="inference",
+    )
     viewer: Viewer | None = None
     try:
         scene = MicroScene(device, args.checkpoint, backend, args.spp)
         print(f"Loaded checkpoint: {scene.checkpoint.path}")
+        print(f"Device backend: {device_backend}")
         print(f"Vector backend: {backend}")
         if args.validate_only:
             return

--- a/experiments/neural_slang/utracer/model.slang
+++ b/experiments/neural_slang/utracer/model.slang
@@ -71,6 +71,24 @@ typealias NeuralSharedMemory = SharedMemorySize<
     kDecoderHidden,
     kDecoderHidden,
     3>;
+#elif NEURAL_TARGET_METAL
+typealias NeuralSharedMemory = SharedMemorySize<
+    float,
+    TargetEnum.Metal,
+    NEURAL_EXECUTION_MODE,
+    kSubgroupSize,
+    kSubgroupCount,
+#if !NEURAL_EXECUTION_INFERENCE
+    kEncoderInputs,
+    kEncoderHidden,
+    kEncoderHidden,
+    kEncoderHidden,
+    kNumLatents,
+#endif
+    kDecoderInputs,
+    kDecoderHidden,
+    kDecoderHidden,
+    3>;
 #else
 typealias NeuralSharedMemory = SharedMemorySize<
     float,

--- a/experiments/neural_slang/utracer/train.py
+++ b/experiments/neural_slang/utracer/train.py
@@ -27,7 +27,13 @@ if __package__:
         load_parameters,
         tensor_from_numpy,
     )
-    from .common import VectorBackend, create_device, require_wave_safe_work_size
+    from .common import (
+        DeviceBackend,
+        VectorBackend,
+        create_device,
+        default_device_backend,
+        require_wave_safe_work_size,
+    )
 else:
     from checkpoint import (
         PARAMETER_COUNT,
@@ -36,7 +42,13 @@ else:
         load_parameters,
         tensor_from_numpy,
     )
-    from common import VectorBackend, create_device, require_wave_safe_work_size
+    from common import (
+        DeviceBackend,
+        VectorBackend,
+        create_device,
+        default_device_backend,
+        require_wave_safe_work_size,
+    )
 
 
 def cosine_schedule(
@@ -61,9 +73,14 @@ class Trainer:
         vector_backend: VectorBackend,
         seed: int,
         resume: Path | None,
+        device_backend: DeviceBackend | None = None,
     ) -> None:
         self.vector_backend = vector_backend
-        self.device = create_device(vector_backend, execution_mode="training")
+        self.device = create_device(
+            vector_backend,
+            device_backend=device_backend,
+            execution_mode="training",
+        )
         self.module = spy.Module(self.device.load_module("training"))
         self.material = CeramicMaterial(self.device)
 
@@ -230,6 +247,11 @@ class Trainer:
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Train the neural.slang ceramic encoder/decoder.")
     parser.add_argument("--vector-backend", choices=("inline", "wave"), default="inline")
+    parser.add_argument(
+        "--device-type",
+        choices=("vulkan", "metal"),
+        default=default_device_backend(),
+    )
     parser.add_argument("--iterations", type=int, default=16_384)
     parser.add_argument("--batch-size", type=int, default=64)
     parser.add_argument("--learning-rate", type=float, default=1e-3)
@@ -254,6 +276,7 @@ def main() -> None:
         raise ValueError("Batch and latent dimensions must be positive")
 
     backend: VectorBackend = args.vector_backend
+    device_backend: DeviceBackend = args.device_type
     require_wave_safe_work_size(backend, args.batch_size * args.batch_size, "training batch")
 
     run_dir = args.run_dir
@@ -263,11 +286,13 @@ def main() -> None:
     run_dir = run_dir.expanduser().resolve()
     run_dir.mkdir(parents=True, exist_ok=True)
     print(f"Run directory: {run_dir}")
+    print(f"Device backend: {device_backend}")
     print(f"Vector backend: {backend}")
 
-    trainer = Trainer(backend, args.seed, args.resume)
+    trainer = Trainer(backend, args.seed, args.resume, device_backend)
     config = {
         "vector_backend": backend,
+        "device_backend": device_backend,
         "batch_size": args.batch_size,
         "learning_rate": args.learning_rate,
         "min_learning_rate": args.min_learning_rate,


### PR DESCRIPTION
## Summary

- add explicit Vulkan/Metal device selection, defaulting to Metal on macOS
- specialize neural shared-memory sizing for `TargetEnum.Metal`
- support InlineVector and WaveTangledVector inference and training on Metal
- keep the Vulkan cooperative-matrix feature gate without incorrectly rejecting Metal `simdgroup_matrix`
- document the Slang ToT requirement and Metal run commands

## Validation

Tested on Apple M4, macOS 26.5.1, using source-built SlangPy with Slang ToT `340a191c5d4686b10b54434a329760abf97a3ed5` (`slangc` reports `2026.13-39-g340a191c5`).

- Metal InlineVector: one-frame path-tracing render
- Metal WaveTangledVector: one-frame path-tracing render
- Metal WaveTangledVector: one training iteration and portable checkpoint save
- Metal checkpoint round trip: reload wave-trained checkpoint into both InlineVector and WaveTangledVector inference
- Vulkan InlineVector and WaveTangledVector: one-frame local render
- `pre-commit run --all-files`
- `git diff --check`